### PR TITLE
Fix ci

### DIFF
--- a/browsercat/sudomcp.yml
+++ b/browsercat/sudomcp.yml
@@ -6,6 +6,7 @@ enabled: true
 config_schema:
   browsercat_api_key:
     type: string
+    default: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 stdio_server_params:
   command: "npx"
   args:

--- a/feishu/sudomcp.yml
+++ b/feishu/sudomcp.yml
@@ -1,4 +1,4 @@
-name: cso1z/feishu
+name: feishu
 title: Feishu Documents
 description: Provides access to Feishu documents for AI-powered tools. Allows creating, reading, and editing documents, supports various content blocks, text formatting, lists, code blocks, and batch operations.
 logo_url: "https://github.com/sudobase-ai/mcp-servers/blob/master/feishu/logo.png?raw=true"
@@ -18,4 +18,3 @@ stdio_server_params:
   env:
     FEISHU_APP_ID: $feishu_app_id
     FEISHU_APP_SECRET: $feishu_app_secret
-enabled: false

--- a/feishu/sudomcp.yml
+++ b/feishu/sudomcp.yml
@@ -18,3 +18,4 @@ stdio_server_params:
   env:
     FEISHU_APP_ID: $feishu_app_id
     FEISHU_APP_SECRET: $feishu_app_secret
+enabled: false

--- a/neon_local/sudomcp.yml
+++ b/neon_local/sudomcp.yml
@@ -14,3 +14,4 @@ stdio_server_params:
     - "start"
     - "$neon_api_key"
 local: true
+enabled: false

--- a/neon_local/sudomcp.yml
+++ b/neon_local/sudomcp.yml
@@ -10,8 +10,7 @@ stdio_server_params:
   command: "npx"
   args:
     - "-y"
-    - "@neondatabase/mcp-server-neon"
+    - "@neondatabase/mcp-server-neon@0.4.1"
     - "start"
     - "$neon_api_key"
 local: true
-enabled: false


### PR DESCRIPTION
Feishu: server logs to file by default, which emits an error message but does not cause CI failure. Was unable to disable logging to file with any environment variables, so these error messages will continue.

Neon-local: recent minor version upgrade 0.4 -> 0.5 appears to require a valid neon API key to initialize the server, so CI is unable to list tools without such a key. For now I pinned to version 0.4.1